### PR TITLE
Prevent a potential NullPointerException.

### DIFF
--- a/src/minecraft/invtweaks/forge/InvTweaksMod.java
+++ b/src/minecraft/invtweaks/forge/InvTweaksMod.java
@@ -71,6 +71,7 @@ public class InvTweaksMod implements InvTweaksAPI {
 
     // Helper for ASM transform of GuiTextField to disable sorting on focus.
     public static void setTextboxModeStatic(boolean enabled) {
-        instance.setTextboxMode(enabled);
+        if (instance != null)
+            instance.setTextboxMode(enabled);
     }
 }


### PR DESCRIPTION
I got a NullPointerException in setTextboxModeStatic after I updated the Forge; this might not be a proper fix (or it might be a bug in Forge), but it sure as hell is better than a crash.
