### PR TITLE
Fixed deobf jar manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,10 @@ task deobfJar(type: Jar) {
     dependsOn classes
 
     from sourceSets.main.output
+    
+    manifest {
+        attributes 'FMLCorePlugin': 'invtweaks.forge.asm.FMLPlugin', 'FMLCorePluginContainsFMLMod': 'true'
+    }
 
     appendix = 'deobf'
 }


### PR DESCRIPTION
The deobfuscated jar does not have the proper manifest attributes.
