### PR TITLE
Fix slot map for crafting table

### DIFF
--- a/src/main/java/invtweaks/container/VanillaSlotMaps.java
+++ b/src/main/java/invtweaks/container/VanillaSlotMaps.java
@@ -98,9 +98,9 @@ public class VanillaSlotMaps {
 
         slotRefs.put(ContainerSection.CRAFTING_OUT, container.inventorySlots.subList(0, 1));
         slotRefs.put(ContainerSection.CRAFTING_IN, container.inventorySlots.subList(1, 10));
-        slotRefs.put(ContainerSection.INVENTORY, container.inventorySlots.subList(10, 45));
-        slotRefs.put(ContainerSection.INVENTORY_NOT_HOTBAR, container.inventorySlots.subList(10, 36));
-        slotRefs.put(ContainerSection.INVENTORY_HOTBAR, container.inventorySlots.subList(36, 45));
+        slotRefs.put(ContainerSection.INVENTORY, container.inventorySlots.subList(10, 46));
+        slotRefs.put(ContainerSection.INVENTORY_NOT_HOTBAR, container.inventorySlots.subList(10, 37));
+        slotRefs.put(ContainerSection.INVENTORY_HOTBAR, container.inventorySlots.subList(37, 46));
 
         return slotRefs;
     }


### PR DESCRIPTION
When sorting items in crafting table window, the following error occurs:

```
InvTweaks: [ERROR] [2] Failed to sort inventory: Index: 35, Size: 35
```

This patch fixes this problem.
Thanks.
