### PR TITLE
Add some fix that exist in 1.5.9

### DIFF
--- a/src/main/java/invtweaks/InvTweaksHandlerShortcuts.java
+++ b/src/main/java/invtweaks/InvTweaksHandlerShortcuts.java
@@ -437,16 +437,18 @@ public class InvTweaksHandlerShortcuts extends InvTweaksObfuscation {
 
                     // Continue if movement succeeded, there is another slot to try, or we're dropping items.
                     // In reverse: fail if movement failed, AND there are no other slots AND we're not dropping.
-                    if(success || (newIndex != toIndex) || (shortcut.action == ShortcutSpecification.Action.DROP)) {
+                    if (newIndex == toIndex) {
+                        break;
+                    } else if (success || shortcut.action == ShortcutSpecification.Action.DROP) {
                         toIndex = newIndex;
                     } else {
                         toIndex = -1;
                     }
                 }
             }
-            if(toIndex == -1) {
-                break;
-            }
+//             if(toIndex == -1) {
+//                 break;
+//             }
         }
     }
 

--- a/src/main/java/invtweaks/InvTweaksHandlerSorting.java
+++ b/src/main/java/invtweaks/InvTweaksHandlerSorting.java
@@ -113,10 +113,7 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
 
     private static boolean canMergeStacks(ItemStack from, ItemStack to) {
         if(areItemsStackable(from, to)) {
-            if(from.stackSize > from.getMaxStackSize()) {
-                return false;
-            }
-            if(to.stackSize < to.getMaxStackSize()) {
+            if (from.stackSize < from.getMaxStackSize() && to.stackSize < to.getMaxStackSize()) {
                 return true;
             }
         }
@@ -192,6 +189,10 @@ public class InvTweaksHandlerSorting extends InvTweaksObfuscation {
                         int[] preferredSlots = rule.getPreferredSlots();
                         int stackToMove = i;
                         for(int k : preferredSlots) {
+                            
+                            if (stackToMove == k) {
+                                continue;
+                            }
                             // Move the stack!
                             int moveResult = move(stackToMove, k, priority);
                             if(moveResult != -1) {

--- a/src/main/java/invtweaks/InvTweaksObfuscation.java
+++ b/src/main/java/invtweaks/InvTweaksObfuscation.java
@@ -231,7 +231,7 @@ public class InvTweaksObfuscation {
     }
 
     public static boolean areItemsStackable(ItemStack itemStack1, ItemStack itemStack2) {
-        return itemStack1 != null && itemStack2 != null && itemStack1.isItemEqual(itemStack2) &&
+        return itemStack1 != null && itemStack2 != null && itemStack1.isItemEqual(itemStack2)
                 && itemStack1.isStackable() && itemStack1 != itemStack2
                 && itemStack1.stackSize < itemStack1.getMaxStackSize()
                 && itemStack2.stackSize < itemStack2.getMaxStackSize() &&

--- a/src/main/java/invtweaks/InvTweaksObfuscation.java
+++ b/src/main/java/invtweaks/InvTweaksObfuscation.java
@@ -234,7 +234,7 @@ public class InvTweaksObfuscation {
         return itemStack1 != null && itemStack2 != null && itemStack1.isItemEqual(itemStack2) &&
                 && itemStack1.isStackable() && itemStack1 != itemStack2
                 && itemStack1.stackSize < itemStack1.getMaxStackSize()
-                && itemStack2.stackSize < itemStack2.getMaxStackSize()
+                && itemStack2.stackSize < itemStack2.getMaxStackSize() &&
                 (!itemStack1.getHasSubtypes() || itemStack1.getItemDamage() == itemStack2.getItemDamage()) &&
                 ItemStack.areItemStackTagsEqual(itemStack1, itemStack2);
     }

--- a/src/main/java/invtweaks/InvTweaksObfuscation.java
+++ b/src/main/java/invtweaks/InvTweaksObfuscation.java
@@ -226,13 +226,15 @@ public class InvTweaksObfuscation {
     // Slot members
 
     public static boolean areSameItemType(ItemStack itemStack1, ItemStack itemStack2) {
-        return itemStack1.isItemEqual(itemStack2) || (itemStack1.isItemStackDamageable() && itemStack1
-                .getItem() == itemStack2.getItem());
+        return itemStack1 != null && itemStack2 != null && (itemStack1.isItemEqual(itemStack2) || (itemStack1.isItemStackDamageable() && itemStack1
+                .getItem() == itemStack2.getItem()));
     }
 
     public static boolean areItemsStackable(ItemStack itemStack1, ItemStack itemStack2) {
         return itemStack1 != null && itemStack2 != null && itemStack1.isItemEqual(itemStack2) &&
-                itemStack1.isStackable() &&
+                && itemStack1.isStackable() && itemStack1 != itemStack2
+                && itemStack1.stackSize < itemStack1.getMaxStackSize()
+                && itemStack2.stackSize < itemStack2.getMaxStackSize()
                 (!itemStack1.getHasSubtypes() || itemStack1.getItemDamage() == itemStack2.getItemDamage()) &&
                 ItemStack.areItemStackTagsEqual(itemStack1, itemStack2);
     }

--- a/src/main/java/invtweaks/container/DirectContainerManager.java
+++ b/src/main/java/invtweaks/container/DirectContainerManager.java
@@ -82,8 +82,8 @@ public class DirectContainerManager implements IContainerManager {
 
         // Use intermediate slot if we have to swap tools, maps, etc.
         assert srcStack != null;
-        if(destStack != null && srcStack.getItem() == destStack.getItem() && (srcStack.getMaxStackSize() == 1 ||
-                srcStack.hasTagCompound() || destStack.hasTagCompound())) {
+        if(destStack != null && srcStack.isItemEqual(destStack) && srcStack.getMaxStackSize() == 1 &&
+                ((srcStack.hasTagCompound() || destStack.hasTagCompound()) && (srcStack.getTagCompound().equals(destStack.getTagCompound())))) {
             int intermediateSlot = getFirstEmptyUsableSlotNumber();
             ContainerSection intermediateSection = getSlotSection(intermediateSlot);
             int intermediateIndex = getSlotIndex(intermediateSlot);


### PR DESCRIPTION
fix Infinite loop when sorting.
add workaround that causing by spigot (just a work around, better than not working)
I am using this patch in my game in spigot. most of fix is add some logic check.

you can reject if there are no problem in 1.6.
