### PR TITLE
Fix #386 Sort buttons can't be clicked when they overlap JEI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ launcher/
 
 # Misc
 *.rej
+classes/

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,16 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'idea'
 
+repositories {
+    maven {
+        // JEI
+        url "http://dvs1.progwml6.com/files/maven"
+    }
+}
+
 dependencies {
     compile 'org.jetbrains:annotations:13.0'
+    deobfCompile "mezz.jei:jei_${mc_version}:${jei_version}"
 }
 
 if(!hasProperty('mod_version')) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ mod_core_hasfmlmod=true
 mc_version=1.9.4
 forge_version=12.17.0.1963
 mcp_version=snapshot_20160614
+jei_version=3.6.8.225
 api_filter=invtweaks/api/**
 curse_id=223094
 curse_filename=Inventory Tweaks

--- a/src/main/java/invtweaks/integration/JeiPlugin.java
+++ b/src/main/java/invtweaks/integration/JeiPlugin.java
@@ -1,0 +1,45 @@
+package invtweaks.integration;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+
+import invtweaks.InvTweaksGuiTooltipButton;
+import mezz.jei.api.BlankModPlugin;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.JEIPlugin;
+import mezz.jei.api.gui.IAdvancedGuiHandler;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.inventory.GuiContainer;
+
+@JEIPlugin
+public class JeiPlugin extends BlankModPlugin {
+	@Override
+	public void register(@Nonnull IModRegistry registry) {
+		registry.addAdvancedGuiHandlers(new IAdvancedGuiHandler<GuiContainer>() {
+			@Nonnull
+			@Override
+			public Class<GuiContainer> getGuiContainerClass() {
+				return GuiContainer.class;
+			}
+
+			@Nullable
+			@Override
+			public List<Rectangle> getGuiExtraAreas(GuiContainer guiContainer) {
+				List<Rectangle> areas = new ArrayList<>();
+
+				for (GuiButton button : guiContainer.buttonList) {
+					if (button instanceof InvTweaksGuiTooltipButton) {
+						Rectangle rectangle = new Rectangle(button.xPosition, button.yPosition, button.width, button.height);
+						areas.add(rectangle);
+					}
+				}
+
+				return areas;
+			}
+		});
+	}
+}


### PR DESCRIPTION
This PR moves JEI out of the way of Inventory Tweak's buttons.
This will not break anything when JEI is not installed, because the plugin class is only ever created by JEI.
Fixes issue #386 

![2016-10-14_01 11 23](https://cloud.githubusercontent.com/assets/916092/19380275/68a246b6-91ab-11e6-9a7f-e4a9c1994676.png)
