### PR TITLE
Fix #386 Sort buttons can't be clicked when they overlap JEI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ launcher/
 
 # Misc
 *.rej
+classes/

--- a/src/main/java/invtweaks/integration/ItemListChecker.java
+++ b/src/main/java/invtweaks/integration/ItemListChecker.java
@@ -1,0 +1,85 @@
+package invtweaks.integration;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Checks if the NEI or JEI item lists are visible on the screen.
+ * Used to make sure InvTweaks buttons do not overlap with the item list.
+ */
+public class ItemListChecker {
+	private Method neiHidden;
+	private Method jeiShown;
+
+	private boolean visible = false;
+	private boolean wasVisible = false;
+
+	public ItemListChecker() {
+		this.neiHidden = getNeiHidden();
+		this.jeiShown = getJeiShown();
+	}
+
+	public boolean isVisible() {
+		wasVisible = visible;
+		visible = isNeiVisible() || isJeiVisible();
+		return visible;
+	}
+
+	public boolean wasVisible() {
+		return wasVisible;
+	}
+
+	private static Method getNeiHidden() {
+		if (Loader.isModLoaded("NotEnoughItems")) {
+			try {
+				Class<?> clientConfig = Class.forName("codechicken.nei.NEIClientConfig");
+				if (clientConfig != null) {
+					return clientConfig.getMethod("isHidden");
+				}
+			} catch (ClassNotFoundException | NoSuchMethodException | SecurityException ignored) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	private static Method getJeiShown() {
+		if (Loader.isModLoaded("JEI")) {
+			try {
+				Class<?> clientConfig = Class.forName("mezz.jei.config.Config");
+				if (clientConfig != null) {
+					return clientConfig.getMethod("isOverlayEnabled");
+				}
+			} catch (ClassNotFoundException | NoSuchMethodException | SecurityException ignored) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	private boolean isNeiVisible() {
+		if (neiHidden != null) {
+			try {
+				return !(Boolean) neiHidden.invoke(null);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				neiHidden = null;
+				return false;
+			}
+		}
+		return false;
+	}
+
+	private boolean isJeiVisible() {
+		if (jeiShown != null) {
+			try {
+				return (Boolean) jeiShown.invoke(null);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				jeiShown = null;
+				return false;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes #386 
Rewritten version of #398
Does not have a compile-time dependency on JEI. Moves the buttons like it does for NEI.
![2016-10-14_14 29 08](https://cloud.githubusercontent.com/assets/916092/19403492/96aaf4ce-921c-11e6-870d-ed096497bde1.png)
![2016-10-14_14 30 27](https://cloud.githubusercontent.com/assets/916092/19403493/96bf32e0-921c-11e6-80cb-da517f595e8e.png)
